### PR TITLE
[no merge] Test using idg allocated memory to create casacore::Array.

### DIFF
--- a/src/cxx/test-alloc.cpp
+++ b/src/cxx/test-alloc.cpp
@@ -66,6 +66,7 @@ int main (int argc, char *argv[]) {
     casacore::Array<complex<float>> cc_data_shared(IPosition(4, 4, nr_baselines, nr_timesteps, nr_channels),
     visibilities_begin_p,
     casacore::StorageInitPolicy::SHARE,
+    // This is probably the wrong allocator, but since casacore won't free the memory this is kinda fine...
     std::allocator<complex<float>>());
 
     std::clog << "Iterator iterate for casacore Array sharing the IDG allocated memory: " << std::endl;

--- a/src/cxx/test-alloc.cpp
+++ b/src/cxx/test-alloc.cpp
@@ -1,0 +1,83 @@
+
+#include "idg-common.h"
+
+#include <casacore/casa/Arrays/Array.h>
+#include "common/Proxy.h"
+#include "CUDA/Generic/Generic.h"
+
+#include <complex>
+#include <assert.h>
+
+using std::complex; using casacore::IPosition;
+
+int main (int argc, char *argv[]) {
+    int nr_baselines= 5;
+    int nr_timesteps = 1;
+    int nr_channels = 1;
+
+    std::clog << "Testing with 1 timestep and 1 channel. The ordering of channel and timesteps \
+    are reversed in casacore and in idg so that's a caveat"
+              << std::endl;
+    std::clog << "Real part is the index, imaginary is the corr {0, 1, 2, 3} -> {XX, XY, YX, YY}" << std::endl;
+    std::clog << "Make a casacore::Array and iterate through it:" << std::endl;
+    // The IPosition constructor goes like (n_dim, n_corr, n_elem)
+    casacore::Array<complex<float>> cc_data(IPosition(2, 4, nr_baselines));
+    for (unsigned int corr=0; corr < 4; ++corr) {
+        for (unsigned int bl=0; bl < nr_baselines; ++ bl) {
+            cc_data(IPosition(2, corr, bl)) = complex<float>(bl, corr);
+        }
+    }
+
+    // prints 0+0j 0+1j 0+2j, 0+3j, 1+0j etc...
+    std::clog << "Iterator iterate: " << std::endl;
+    for (auto elem : cc_data) {
+        std::clog << elem.real() << "+" << elem.imag() << "j" <<std::endl;
+    }
+
+    std::clog << "Iterate with a pointer: " << std::endl;
+    for (complex<float>* p = cc_data.data(); p < (cc_data.data() + cc_data.size()); ++p) {
+        std::clog << p->real() << "+" << p->imag() << "j" <<std::endl;
+    }
+
+    std::clog << "Make an idg::Array3D<Matrix<2x2>>:" << std::endl;
+    
+    idg::proxy::cuda::Generic proxy;
+    idg::Array3D<idg::Visibility<complex<float>>> visibilities =
+            proxy.allocate_array3d<idg::Matrix2x2<complex<float>>>(nr_baselines, nr_timesteps, nr_channels);
+    
+    for (unsigned int bl=0; bl < 5; ++ bl) {
+        visibilities(bl, 0, 0) = {
+            complex<float>(bl, 0),
+            complex<float>(bl, 1),
+            complex<float>(bl, 2),
+            complex<float>(bl, 3)};
+    }
+
+    std::clog << "Iterate through idg:Array3D<Matrix2x2> with a pointer" << std::endl;
+    // stuck: Matrix2x2 is a struct.
+    complex<float> *visibilities_begin_p = &(visibilities(0, 0, 0).xx);
+    {
+        std::cout << visibilities.size() << std::endl;
+        auto end_p = visibilities_begin_p + visibilities.size() * 4;
+        for (complex<float> *p = visibilities_begin_p; p < end_p; ++p)
+        {
+            std::clog << p->real() << "+" << p->imag() << "j" << std::endl;
+        }
+    }
+
+    casacore::Array<complex<float>> cc_data_shared(IPosition(4, 4, nr_baselines, nr_timesteps, nr_channels),
+    visibilities_begin_p,
+    casacore::StorageInitPolicy::SHARE,
+    std::allocator<complex<float>>());
+
+    std::clog << "Iterator iterate for casacore Array sharing the IDG allocated memory: " << std::endl;
+    for (auto elem : cc_data_shared) {
+        std::clog << elem.real() << "+" << elem.imag() << "j" <<std::endl;
+    }
+    assert(visibilities_begin_p == cc_data_shared.data());
+    /**
+    step 3 is to read from a measurement set and make sure that
+    data are in the right order.
+    **/
+    
+}

--- a/src/cxx/test-alloc.cpp
+++ b/src/cxx/test-alloc.cpp
@@ -54,10 +54,8 @@ int main (int argc, char *argv[]) {
     }
 
     std::clog << "Iterate through idg:Array3D<Matrix2x2> with a pointer" << std::endl;
-    // stuck: Matrix2x2 is a struct.
     complex<float> *visibilities_begin_p = &(visibilities(0, 0, 0).xx);
     {
-        std::cout << visibilities.size() << std::endl;
         auto end_p = visibilities_begin_p + visibilities.size() * 4;
         for (complex<float> *p = visibilities_begin_p; p < end_p; ++p)
         {


### PR DESCRIPTION
Verified that data ordering is what I expect and the data() pointer points to the right place.

Three caveats:
- the ordering of timesteps and channel in casacore and IDG are logically reversed, the data types don't care though.
- IDG uses a struct called `Matrix2x2={xx, xy, yx, yy}` to store visibilities. I hackishly used the pointer to the xx of the first visibility as the pointer to the beginning of the chunk of data to pass to casacore and that seemed to work...fine. I don't know if this is guaranteed to work (I'm tempted to say yes when it's an array of structs).
- I probably passed the wrong allocator.

Output:
```
Testing with 1 timestep and 1 channel. The ordering of channel and timesteps     are reversed in casacore and in idg so that's a caveat
Real part is the index, imaginary is the corr {0, 1, 2, 3} -> {XX, XY, YX, YY}
Make a casacore::Array and iterate through it:
Iterator iterate: 
0+0j
0+1j
0+2j
0+3j
1+0j
1+1j
1+2j
1+3j
2+0j
2+1j
2+2j
2+3j
3+0j
3+1j
3+2j
3+3j
4+0j
4+1j
4+2j
4+3j
Iterate with a pointer: 
0+0j
0+1j
0+2j
0+3j
1+0j
1+1j
1+2j
1+3j
2+0j
2+1j
2+2j
2+3j
3+0j
3+1j
3+2j
3+3j
4+0j
4+1j
4+2j
4+3j
Make an idg::Array3D<Matrix<2x2>>:
Devices: 
GeForce RTX 3090
	Device memory : 23970 Mb  / 24268 Mb (free / total)
	Shared memory : 48.00 Kb
	Clk frequency : 1695 Ghz
	Mem frequency : 9751 Ghz
	Number of SM  : 82
	Mem bus width : 384 bit
	Mem bandwidth : 936 GB/s
	Number of threads  : 1536
	Capability    : 86
	Unified memory : 1


Compiler flags: 
 -use_fast_math -lineinfo -src-in-ptx -arch=sm_86 -DNR_POLARIZATIONS=4 -I/opt/include

Iterate through idg:Array3D<Matrix2x2> with a pointer
0+0j
0+1j
0+2j
0+3j
1+0j
1+1j
1+2j
1+3j
2+0j
2+1j
2+2j
2+3j
3+0j
3+1j
3+2j
3+3j
4+0j
4+1j
4+2j
4+3j
Iterator iterate for casacore Array sharing the IDG allocated memory: 
0+0j
0+1j
0+2j
0+3j
1+0j
1+1j
1+2j
1+3j
2+0j
2+1j
2+2j
2+3j
3+0j
3+1j
3+2j
3+3j
4+0j
4+1j
4+2j
4+3j
```